### PR TITLE
Misc Entry Tags

### DIFF
--- a/types/Entry/Entry.ts
+++ b/types/Entry/Entry.ts
@@ -1,5 +1,5 @@
 import { EntryState } from './State';
-import { EntryFacultyTags } from './Tags';
+import { EntryFacultyTags, EntryMiscTags } from './Tags';
 import { UserReference } from '../User';
 import { GuildData } from './GuildData';
 import { ActionLog } from './ActionLog';
@@ -40,7 +40,10 @@ interface BaseEntry {
 
     likes: number;
 
-    facultyTags: EntryFacultyTags;
+    tags: {
+        faculty: EntryFacultyTags;
+        misc: EntryMiscTags;
+    };
 }
 
 /** An entry that has not yet been looked at by a moderator. */

--- a/types/Entry/Tags.ts
+++ b/types/Entry/Tags.ts
@@ -12,3 +12,8 @@ export enum EntryFacultyTags {
     Science = 1 << 10,
     Statistics = 1 << 11,
 }
+
+export enum EntryMiscTags {
+    /** This server is run by UoA Discords staff. */
+    Partnered = 1 << 0,
+}


### PR DESCRIPTION
Extra non-faculty tags for entries, so far just `partnered` (meaning this server is run by UoA Discords staff), but other suggestions are welcome.